### PR TITLE
fix small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Services Summit Sept 14, 2021: [Making Financial Data More Accessible in the Clo
 ## FAQ
 *How do I contribute my own examples?*  
 
-- Although we're extremely excited to receive contributions from the community, we're still working on the best mechanism to take in examples from external sources.  Please bare with us in the short-term if pull requests take longer than expected or are closed.
+- Although we're extremely excited to receive contributions from the community, we're still working on the best mechanism to take in examples from external sources.  Please bear with us in the short-term if pull requests take longer than expected or are closed.
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a fix for a small typo. The word should be spelled "bear" as in bear with us. I know it's a small thing, but it was bothering me.

Unless you intentionally used the word "bare" to mean take off your clothes while you wait, in which case please reject this PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
