### PR TITLE
Fix .aws.list_kx_clusters[] and typo in comment

### DIFF
--- a/ManagedkdbInsights/q/aws.q
+++ b/ManagedkdbInsights/q/aws.q
@@ -58,6 +58,7 @@ list_kx_clusters_full:{[]
 / see https://docs.aws.amazon.com/finspace/latest/userguide/interacting-with-kdb-loading-code.html
 list_kx_clusters:{[]
    clusters: list_kx_clusters_full[];
+   $[not `clusterDescription in cols clusters;clusters:update clusterDescription:(count clusters)#enlist"" from clusters;];
    select cluster_name: clusterName, status, cluster_type:clusterType, description:clusterDescription from clusters
  }
 
@@ -291,7 +292,7 @@ update_kx_database:{[databaseName;properties]
 /     .aws.update_kx_cluster_databases[
 /        "MyCluster";
 /        .aws.sdbs[.aws.db["MyDB";"osSoXB58eSXuDXLZFTCHyg";.aws.cache["";"/"]]];
-/        .aws.sdep"ROLLING"
+/        .aws.sdep["ROLLING"]
 /     ]
 update_kx_cluster_databases:{[clusterName;databases;properties]
    $[clusterName~"";clusterName:prefs`clusterName;];


### PR DESCRIPTION
Today .aws.list_kx_clusters will fail if all the clusters returned do not have a description. With this fix the return will still work. 

Current behavior: 
```
q).aws.list_kx_clusters[]
'clusterDescription
  [1]  /Users/pelarso/code/fork-amazon-finspace-examples/ManagedkdbInsights/q/aws.q:61: .aws.list_kx_clusters:
   clusters: list_kx_clusters_full[];
   select cluster_name: clusterName, status, cluster_type:clusterType, description:clusterDescription from clusters
   ^
 }
```
With this change: 
```
q).aws.list_kx_clusters[]
cluster_name            status    cluster_type description
----------------------------------------------------------
"DEVCluster-regression" "RUNNING" "DEV"        ""
"RDBCluster-regression" "RUNNING" "RDB"        ""
"HDBCluster-regression" "RUNNING" "HDB"        ""
```

This PR also includes a fix to the documentation of `.aws.update_kx_cluster_databases`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
