### PR TITLE
Add .aws.stop_current_kx_cluster_creation

### DIFF
--- a/ManagedkdbInsights/q/aws.q
+++ b/ManagedkdbInsights/q/aws.q
@@ -371,6 +371,18 @@ wait_for_status:{[function;args;statuses;frequency;timeout]
    res 
  }
 
+/ ---------------
+/ Public Initialization API
+/ ---------------
+
+/ This function is provided to keep compatibility with the library within FinSpace
+/ see https://docs.aws.amazon.com/finspace/latest/userguide/interacting-with-kdb-loading-code.html
+/ here, it logs a statement about what would have happened if it were called on an actual cluster,
+/ but has no other effect.
+stop_current_kx_cluster_creation:{[message]
+  show "Cluster would be put in the CREATE_FAILED state if called from initialization script."
+  }
+
 / ----------------
 / Helper Functions
 / ----------------


### PR DESCRIPTION
Adds .aws.stop_current_kx_cluster_creation for
compatibility with the library within FinSpace.

The library within FinSpace now supports an API called `.aws.stop_current_kx_cluster_creation`. This API only has an effect if called from the initialization script of a cluster, so the version added here takes no action, but logs a statement about what would have happened if it was called from on a cluster.  (https://docs.aws.amazon.com/finspace/latest/userguide/interacting-with-kdb-loading-code.html)

The new API behaves the following way: 
```
q).aws.stop_current_kx_cluster_creation[""]
"Cluster would be put in the CREATE_FAILED state if called from initialization script."
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
