### PR TITLE
Allow Empty Cache Configuration and Changeset in .aws.db

### DIFF
--- a/ManagedkdbInsights/q/aws.q
+++ b/ManagedkdbInsights/q/aws.q
@@ -481,7 +481,7 @@ db:{[databaseName;changesetId;caches]
    $[99h=type caches;caches:enlist caches;]; 
    db_config: `databaseName`changesetId`cacheConfigurations!(databaseName;changesetId;caches);
    $[changesetId~""; db_config: db_config _ `changesetId;];
-   $[caches~""; db_config: db_config _ `cacheConfigurations;];
+   $[caches~(); db_config: db_config _ `cacheConfigurations;];
    db_config
  }
 

--- a/ManagedkdbInsights/q/aws.q
+++ b/ManagedkdbInsights/q/aws.q
@@ -479,7 +479,10 @@ cache:{[cacheType;dbPaths]
 db:{[databaseName;changesetId;caches]
    $[databaseName~"";databaseName:prefs`databaseName;];
    $[99h=type caches;caches:enlist caches;]; 
-   `databaseName`changesetId`cacheConfigurations!(databaseName;changesetId;caches)
+   db_config: `databaseName`changesetId`cacheConfigurations!(databaseName;changesetId;caches);
+   $[changesetId~""; db_config: db_config _ `changesetId;];
+   $[caches~""; db_config: db_config _ `cacheConfigurations;];
+   db_config
  }
 
 / build a string with a list of databases for functions that require it


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will allow ```.aws.db``` to be called with empty parameters for cacheConfiguration and changesetId to allow for the full functionality of the finspace CLI. 

Example call for latest changesetId and empty cacheConfiguration: ```.aws.db["ExampleDb"; ""; ()]```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
